### PR TITLE
Update graphite.theme.css

### DIFF
--- a/src/renderer/assets/themes/graphite.theme.css
+++ b/src/renderer/assets/themes/graphite.theme.css
@@ -17,7 +17,7 @@
   --editorColor60: rgba(43, 48, 50, .6);
   --editorColor50: rgba(43, 48, 50, .5);
   --editorColor40: rgba(43, 48, 50, .4);
-  --editorColor30: rgba(43, 48, 50, .3);
+  --editorColor30: rgba(150, 150, 150, .8);
   --editorColor10: rgba(43, 48, 50, .1);
   --editorColor04: rgba(43, 48, 50, .04);
   --editorBgColor: #f7f7f7;


### PR DESCRIPTION
Changed the color value of the word count color to be viewed against the sidebar in the graphite-light theme.

<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #2363
| License           | MIT

### Description
Fixed the color of the word counter in the graphite light theme so that it is viewable on the side bar.
![image](https://user-images.githubusercontent.com/49735648/99142536-1eecc680-2613-11eb-99e0-fda86fec9957.png)
